### PR TITLE
DM-24742: Explicitly add iconv to LDFLAGS to get conda iconv

### DIFF
--- a/ups/eupspkg.cfg.sh
+++ b/ups/eupspkg.cfg.sh
@@ -1,6 +1,7 @@
 
 CONFIGURE_OPTIONS="--prefix=$PREFIX --libdir=$PREFIX/lib"
 
+LDFLAGS="$LDFLAGS -liconv"
 
 install()
 {


### PR DESCRIPTION
Supports the move to conda-forge third parties 